### PR TITLE
Update sudo -> become (sudo is deprecated)

### DIFF
--- a/centos/playbooks/configure_master_node.yml
+++ b/centos/playbooks/configure_master_node.yml
@@ -17,7 +17,7 @@
 
   - name: Storing Logs and Generated token for future purpose.
     local_action: copy content={{ output.stdout }} dest={{ token_file }}
-    sudo: False 
+    become: False
 
   - name: Copying required files
     shell: |


### PR DESCRIPTION
`sudo` is deprecated and should be changed to `become`
It's currently causing an error:
````
ERROR! conflicting action statements: copy, sudo

The error appears to be in '/<repo>/centos/playbooks/configure_master_node.yml': line 19, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


  - name: Storing Logs and Generated token for future purpose.
    ^ here
```