### PR TITLE
Fix more pod networking issues

### DIFF
--- a/centos/hosts
+++ b/centos/hosts
@@ -1,14 +1,14 @@
-[kubernetes-master-nodes]
+[kubernetes_master_nodes]
 kubernetes-master ansible_host=10.11.12.2
 
-[kubernetes-worker-nodes]
+[kubernetes_worker_nodes]
 kubernetes-worker1 ansible_host=10.11.12.3
 kubernetes-worker2 ansible_host=10.11.12.4
 
 
 [kubernetes:children]
-kubernetes-worker-nodes
-kubernetes-master-nodes
+kubernetes_worker_nodes
+kubernetes_master_nodes
 
 [kubernetes:vars]
 ansible_password=vagrant

--- a/centos/playbooks/configure_master_node.yml
+++ b/centos/playbooks/configure_master_node.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: kubernetes-master-nodes
+- hosts: kubernetes_master_nodes
   become: yes
   vars_files:
   - env_variables

--- a/centos/playbooks/configure_worker_nodes.yml
+++ b/centos/playbooks/configure_worker_nodes.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: kubernetes-worker-nodes
+- hosts: kubernetes_worker_nodes
   become: yes
   vars_files:
   - env_variables

--- a/centos/playbooks/setting_up_nodes.yml
+++ b/centos/playbooks/setting_up_nodes.yml
@@ -42,7 +42,7 @@
     with_items: "{{ services }}"
 
   - name: Allow Network Ports in Firewalld
-    firewalld:
+    ansible.posix.firewalld:
      port: "{{ item }}"
      state: enabled
      permanent: yes

--- a/centos/playbooks/setting_up_nodes.yml
+++ b/centos/playbooks/setting_up_nodes.yml
@@ -47,7 +47,7 @@
      state: enabled
      permanent: yes
      immediate: yes
-    with_items: "{{ master_ports if ('kubernetes-master-nodes' in group_names) else worker_ports }}"
+    with_items: "{{ master_ports if ('kubernetes_master_nodes' in group_names) else worker_ports }}"
 
   - name: Allow masquerading in Firewalld
     ansible.posix.firewalld:

--- a/centos/playbooks/setting_up_nodes.yml
+++ b/centos/playbooks/setting_up_nodes.yml
@@ -49,5 +49,12 @@
      immediate: yes
     with_items: "{{ master_ports if ('kubernetes-master-nodes' in group_names) else worker_ports }}"
 
+  - name: Allow masquerading in Firewalld
+    ansible.posix.firewalld:
+      masquerade: "yes"
+      state: enabled
+      permanent: yes
+      immediate: yes
+
   - name: Enabling Bridge Firewall Rule
     shell: "echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables"


### PR DESCRIPTION
This PR fixes a few issues I found while setting up a cluster:

- There were warnings about the firewalld module being replaced with ansible.posix.firewalld. I replaced the module name.
- There were warnings about the use of the dash character in Ansible group names. I replaced them with underscores.
- Pods did not seem to have access to the internet. Enabling masquerading in firewalld fixed it.